### PR TITLE
NoBaseType && KeyPart attributes, ver 1.0.1

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.FluidEntity/Attributes/KeyPartAttribute.cs
+++ b/src/Microsoft.EntityFrameworkCore.FluidEntity/Attributes/KeyPartAttribute.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    /// Mark property as a part of entity key 
+    /// </summary>       
+    [AttributeUsage(AttributeTargets.Property)]
+    public class KeyPartAttribute: Attribute
+    {
+        /// <summary>
+        /// KeyPart attribute default constructor.
+        /// Mark property as a part of entity key 
+        /// </summary>         
+        public KeyPartAttribute(){}        
+    }    
+}

--- a/src/Microsoft.EntityFrameworkCore.FluidEntity/Attributes/NoBaseTypeAttribute.cs
+++ b/src/Microsoft.EntityFrameworkCore.FluidEntity/Attributes/NoBaseTypeAttribute.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    /// Mark the entity as has no base type
+    /// This is equivalent .HasBaseType((Type)null) fluent api
+    /// but it can be applied at top class hierarchy level
+    /// </summary>       
+    [AttributeUsage(AttributeTargets.Class)]
+    public class NoBaseTypeAttribute : Attribute
+    {
+        /// <summary>
+        /// Mark the entity as has no base type
+        /// This is equivalent .HasBaseType((Type)null) fluent api 
+        /// but it can be applied at top class hierarchy level
+        /// </summary>         
+        public NoBaseTypeAttribute() {}
+    }
+}

--- a/src/Microsoft.EntityFrameworkCore.FluidEntity/Microsoft.EntityFrameworkCore.FluidEntity.csproj
+++ b/src/Microsoft.EntityFrameworkCore.FluidEntity/Microsoft.EntityFrameworkCore.FluidEntity.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>FluidNames</PackageId>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <Authors>Aleksandr Kolesnikov</Authors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Microsoft.EntityFrameworkCore.FluidEntity</AssemblyName>
@@ -10,7 +10,8 @@
     <PackageProjectUrl>https://github.com/kolesnikovav/FluidNames</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/kolesnikovav/FluidNames.git</RepositoryUrl>        
+    <RepositoryUrl>https://github.com/kolesnikovav/FluidNames.git</RepositoryUrl>
+    <Description>A plugin for Microsoft.EntityFrameworkCore to support automatically names tables and fields</Description>       
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />


### PR DESCRIPTION
Adding **NoBaseType** attribute.
This is similiar with fluent api method HasBaseType
```csharp
 modelBuilder.HasBaseType((Type)null)
```
but it can be specified at top class hierarchy level
**KeyPart** attribute is similiar with HasKey
```csharp
 modelBuilder.HasKey(...)
```


