### PR TITLE
Automaticly create ValueConverter for entities / properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,24 @@
 # Why
 Some database providers doesn't allow long table, fields, keys names. If you have > 20 several entity types, manualy creating table/ field names may be tediously.
 This library allow you set start symblos for tables and fields and create unique fluid names for each entity.
+Anover feature is creating ``` ValueConverter ``` for each entities. This is used to create relation between Entity and CLR Type. For creation of ``` ValueConverter ``` Key property of Entity is used. With this feature, you can refference the property of entity to anover entity type directly.
+
+```csharp
+    public class AnimalOwner
+    {
+        [Key]
+        public Guid Id {get;set;}
+        public string Name {get;set;}
+    }
+    public class Dog
+    {
+        //... you code ...//
+        public AnimalOwner Owner {get;set;} // This is valid Type, because of ValueConverter is present!
+    }
+```
+You can disable autocreate ``` ValueConverter ``` for entity/property by setting ```[NoValueConverter]``` attribute.
+
+
 
 # How to use
 

--- a/src/Microsoft.EntityFrameworkCore.FluidEntity/Attributes/NoValueConverterAttribute.cs
+++ b/src/Microsoft.EntityFrameworkCore.FluidEntity/Attributes/NoValueConverterAttribute.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    /// Disable create ValueConverter for entity/property 
+    /// </summary>       
+    [AttributeUsage(AttributeTargets.Class| AttributeTargets.Property)]
+    public class NoValueConverterAttribute: Attribute
+    {
+        /// <summary>
+        /// Disable create ValueConverter for entity/property.
+        /// </summary>         
+        public NoValueConverterAttribute(){}        
+    }    
+}

--- a/src/Microsoft.EntityFrameworkCore.FluidEntity/Extentions/ModelBuilderExtention.cs
+++ b/src/Microsoft.EntityFrameworkCore.FluidEntity/Extentions/ModelBuilderExtention.cs
@@ -72,11 +72,6 @@ namespace Microsoft.EntityFrameworkCore
             MethodInfo mFirstOrDefault = typeof(Queryable).GetMethods(BindingFlags.Public | BindingFlags.Static)
             .Where(v => v.Name == "FirstOrDefault" && v.GetParameters().Count() == 2).First();
             MethodInfo mGFirstOrDefault = mFirstOrDefault.MakeGenericMethod(TModel); 
-            Expression constContext = Expression.Constant(context);
-            MemberExpression expressionDBSet = Expression.Property(constContext, nameDBSet);
-            List<ParameterExpression> p = new List<ParameterExpression>();
-            p.Add(parameterClrFind);            
-            Expression FindPredicateLambda = Expression.Lambda(FindPredicate,p );
             MemberExpression propertyDBSet = Expression.Property(Expression.Constant(context), nameDBSet);
             Expression callExpr = Expression.Call(
                                     mGFirstOrDefault ,

--- a/src/Microsoft.EntityFrameworkCore.FluidEntity/Microsoft.EntityFrameworkCore.FluidEntity.csproj
+++ b/src/Microsoft.EntityFrameworkCore.FluidEntity/Microsoft.EntityFrameworkCore.FluidEntity.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>FluidNames</PackageId>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <Authors>Aleksandr Kolesnikov</Authors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Microsoft.EntityFrameworkCore.FluidEntity</AssemblyName>
@@ -11,7 +11,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/kolesnikovav/FluidNames.git</RepositoryUrl>
-    <Description>A plugin for Microsoft.EntityFrameworkCore to support automatically names tables and fields</Description>       
+    <Description>A plugin for Microsoft.EntityFrameworkCore to support automatically names tables and fields. Autocreate ValueConverter for refferenced entities/ properties.</Description>       
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />


### PR DESCRIPTION
Currently, EF Core does not support refference the property to entity. It requres creating the instance of ValueConverter. This PR make it automaticly and made this code
```csharp
    public class AnimalOwner
    {
        [Key]
        public Guid Id {get;set;}
        public string Name {get;set;}
    }
    public class Dog
    {
        //... you code ...//
       // This is valid Type, because of ValueConverter is present!
        public AnimalOwner Owner {get;set;} 
    }
```
valid! 
